### PR TITLE
Update tests rule to use tiny.en model by default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -286,5 +286,6 @@ tiny.en tiny base.en base small.en small medium.en medium large-v1 large: main
 #
 
 .PHONY: tests
+MODEL ?= tiny.en
 tests:
-	bash ./tests/run-tests.sh
+	bash ./tests/run-tests.sh $(MODEL)

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -15,6 +15,9 @@
 #
 #   ./tests/run-tests.sh <model_name>
 #
+# When invoked via 'make tests', <model_name> defaults to 'tiny.en'.
+# You can override it with 'make MODEL=<name> tests'.
+#
 
 cd `dirname $0`
 


### PR DESCRIPTION
## Summary
- modify `Makefile` so `make tests` runs with a model passed in via `MODEL` (default `tiny.en`)
- document default model usage in `tests/run-tests.sh`

## Testing
- `make tests` *(fails: Model tiny.en not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842f854140083338a9071c4b0e9ebd5