### PR TITLE
Fix loader read return length

### DIFF
--- a/whisper.cpp
+++ b/whisper.cpp
@@ -2522,7 +2522,7 @@ struct whisper_context * whisper_init_from_file_no_state(const char * path_model
     loader.read = [](void * ctx, void * output, size_t read_size) {
         std::ifstream * fin = (std::ifstream*)ctx;
         fin->read((char *)output, read_size);
-        return read_size;
+        return (size_t) fin->gcount();
     };
 
     loader.eof = [](void * ctx) {


### PR DESCRIPTION
## Summary
- fix the file loader to return the number of bytes actually read

## Testing
- `make clean`
- `make examples -j$(nproc)`
- `bash tests/run-tests.sh tiny.en` *(fails: Model tiny.en not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842ee951c6c8333bd452a84abeee846